### PR TITLE
Speed up parsing IPv6 addresses

### DIFF
--- a/ifaddr/_shared.py
+++ b/ifaddr/_shared.py
@@ -179,13 +179,13 @@ def sockaddr_to_ip(sockaddr_ptr: 'ctypes.pointer[sockaddr]') -> Optional[Union[_
         if sockaddr_ptr[0].sa_familiy == socket.AF_INET:
             ipv4 = ctypes.cast(sockaddr_ptr, ctypes.POINTER(sockaddr_in))
             ippacked = bytes(bytearray(ipv4[0].sin_addr))
-            ip = str(ipaddress.ip_address(ippacked))
+            ip = str(ipaddress.IPv4Address(ippacked))
             return ip
         elif sockaddr_ptr[0].sa_familiy == socket.AF_INET6:
             ipv6 = ctypes.cast(sockaddr_ptr, ctypes.POINTER(sockaddr_in6))
             flowinfo = ipv6[0].sin6_flowinfo
             ippacked = bytes(bytearray(ipv6[0].sin6_addr))
-            ip = str(ipaddress.ip_address(ippacked))
+            ip = str(ipaddress.IPv6Address(ippacked))
             scope_id = ipv6[0].sin6_scope_id
             return (ip, flowinfo, scope_id)
     return None
@@ -193,7 +193,8 @@ def sockaddr_to_ip(sockaddr_ptr: 'ctypes.pointer[sockaddr]') -> Optional[Union[_
 
 def ipv6_prefixlength(address: ipaddress.IPv6Address) -> int:
     prefix_length = 0
+    address_as_int = int(address)
     for i in range(address.max_prefixlen):
-        if int(address) >> i & 1:
+        if address_as_int >> i & 1:
             prefix_length = prefix_length + 1
     return prefix_length

--- a/ifaddr/test_ifaddr.py
+++ b/ifaddr/test_ifaddr.py
@@ -48,6 +48,6 @@ def test_netifaces_compatibility() -> None:
     # assert ifaddr.netifaces.gateways() == netifaces.gateways()
 
 
-def test_ipv6_prefixlength():
+def test_ipv6_prefixlength() -> None:
     assert ipv6_prefixlength(ipaddress.IPv6Address('ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff')) == 128
     assert ipv6_prefixlength(ipaddress.IPv6Address('ffff:ffff:ffff:ffff::')) == 64

--- a/ifaddr/test_ifaddr.py
+++ b/ifaddr/test_ifaddr.py
@@ -1,12 +1,13 @@
 # Copyright (C) 2015 Stefan C. Mueller
 
+import ipaddress
 import unittest
 
 import pytest
 
 import ifaddr
 import ifaddr.netifaces
-
+from ifaddr._shared import ipv6_prefixlength
 
 try:
     import netifaces
@@ -26,7 +27,6 @@ class TestIfaddr(unittest.TestCase):
     """
 
     def test_get_adapters_contains_localhost(self) -> None:
-
         found = False
         adapters = ifaddr.get_adapters()
         for adapter in adapters:
@@ -46,3 +46,8 @@ def test_netifaces_compatibility() -> None:
     #     print(interface)
     #     assert ifaddr.netifaces.ifaddresses(interface) == netifaces.ifaddresses(interface)
     # assert ifaddr.netifaces.gateways() == netifaces.gateways()
+
+
+def test_ipv6_prefixlength():
+    assert ipv6_prefixlength(ipaddress.IPv6Address('ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff')) == 128
+    assert ipv6_prefixlength(ipaddress.IPv6Address('ffff:ffff:ffff:ffff::')) == 64


### PR DESCRIPTION
- Only do the int conversion once in ipv6_prefixlength since
  the underlying ipaddress module will do it every time
- Avoid trying to construct ipv4 addresses when we know
  its an ipv6 address in sockaddr_to_ip since ip_address
  tries ipv4 first, fails, and than tries ipv6